### PR TITLE
When one parameter contains blank, it should be wrapped with `"`.

### DIFF
--- a/runx/runx.py
+++ b/runx/runx.py
@@ -76,6 +76,8 @@ def expand_hparams(hparams):
         if type(val) is bool:
             if val is True:
                 cmd += '--{} '.format(field)
+        if type(val) is dict:
+            cmd += '--{} "{}" '.format(field, val)
         elif val != 'None':
             cmd += '--{} {} '.format(field, val)
     return cmd


### PR DESCRIPTION
# Hope to let argparse to interpreter `dict` type

## 1. I define `test_config.yml` file as following:
```
CMD: "python train.py"

HPARAMS:
   lr: [0.01, 0.02]
   momentum: 0.5
   dataset:
     name: 'aerial'
     class: 'dataset.AerialDataset'
     root-dir: '/home/cv/dataset/aerial'
     train:
       dir: 'train'
       batch_size: 10
```

## 2. I execute `python -m runx.runx test_config.yml -i -n`, then command line prints:
```
python train.py --lr 0.01 --momentum 0.5 --dataset {'name': 'aerial', 'class': 'dataset.AerialDataset', 'root-dir': '/home/cv/dataset/aerial', 'train': {'dir': 'train', 'batch_size': 10}}
python train.py --lr 0.02 --momentum 0.5 --dataset {'name': 'aerial', 'class': 'dataset.AerialDataset', 'root-dir': '/home/cv/dataset/aerial', 'train': {'dir': 'train', 'batch_size': 10}}
```
You can notice that parameter `dataset` is a `dict` type, but it can't be interpreterd by `argparse module` with `eval` type.  This is because `dataset` parameter is truncated into `{'name':`, this style cannot be interpreter by `eval` function.

## 3. So I try to transform `dict` into `str`. And set `eval` type of argparse arguments, this would solve this problem. But it need `runx` composite dict paramter wapped with `"`. Therefore, I add this feature in this commit.